### PR TITLE
Possibly fixed quest blackscreen at end of beatmap bug, sends players without countdown the countdown if they were not in the lobby at the countdown start and fixed manager disconnect and null beatmap on countdown end

### DIFF
--- a/BeatTogether.DedicatedServer.Kernel/Abstractions/IPlayer.cs
+++ b/BeatTogether.DedicatedServer.Kernel/Abstractions/IPlayer.cs
@@ -27,6 +27,8 @@ namespace BeatTogether.DedicatedServer.Kernel.Abstractions
         GameplayModifiers Modifiers { get; set; }
         PlayerStateHash State { get; set; }
 
+        bool WasActiveAtCountdownStart { get; set; }
+
         public bool IsManager { get; }
         public bool CanRecommendBeatmaps { get; }
         public bool CanRecommendModifiers { get; }

--- a/BeatTogether.DedicatedServer.Kernel/Enums/GameplayServerMode.cs
+++ b/BeatTogether.DedicatedServer.Kernel/Enums/GameplayServerMode.cs
@@ -4,6 +4,7 @@
     {
         Countdown = 0,
         Managed = 1,
-        QuickStartOneSong = 2
+        QuickStartOneSong = 2,
+        Tournament = 3
     }
 }

--- a/BeatTogether.DedicatedServer.Kernel/Enums/SongSelectionMode.cs
+++ b/BeatTogether.DedicatedServer.Kernel/Enums/SongSelectionMode.cs
@@ -5,6 +5,7 @@
         Vote = 0,
         Random = 1,
         ManagerPicks = 2,
-        RandomPlayerPicks = 3
+        RandomPlayerPicks = 3,
+        ServerPicks = 4
     }
 }

--- a/BeatTogether.DedicatedServer.Kernel/Managers/LobbyManager.cs
+++ b/BeatTogether.DedicatedServer.Kernel/Managers/LobbyManager.cs
@@ -346,8 +346,8 @@ namespace BeatTogether.DedicatedServer.Kernel.Managers
                         return null;
                     return voteDictionary.OrderByDescending(n => n.Value).First().Key;
                 case SongSelectionMode.RandomPlayerPicks:
-                    if (SelectedBeatmap == null)
-                        return _playerRegistry.Players[new Random().Next(_playerRegistry.Players.Count)].BeatmapIdentifier;
+                    if (SelectedBeatmap != _lastBeatmap)
+                        return _playerRegistry.Players[new Random().Next(_playerRegistry.Players.Count)].BeatmapIdentifier; //TODO, make a random player the manager for that beatmap round for randomplayer chooses setting
                     return SelectedBeatmap;
             };
             return null;

--- a/BeatTogether.DedicatedServer.Kernel/PacketHandlers/MultiplayerSession/MenuRpc/SetIsInLobbyPacketHandler.cs
+++ b/BeatTogether.DedicatedServer.Kernel/PacketHandlers/MultiplayerSession/MenuRpc/SetIsInLobbyPacketHandler.cs
@@ -34,8 +34,8 @@ namespace BeatTogether.DedicatedServer.Kernel.PacketHandlers.MultiplayerSession.
                 $"Handling packet of type '{nameof(SetIsInLobbyPacket)}' " +
                 $"(SenderId={sender.ConnectionId}, InLobby={packet.IsInLobby})."
             );
-            if (_instance.State == MultiplayerGameState.Game && packet.IsInLobby == true && _playerRegistry.Players.TrueForAll(p => p.InLobby))
-                _gameplayManager.SignalRequestReturnToMenu();
+            //if (_instance.State == MultiplayerGameState.Game && packet.IsInLobby == true && _playerRegistry.Players.TrueForAll(p => p.InLobby))
+            //    _gameplayManager.SignalRequestReturnToMenu();
 
             if (packet.IsInLobby && !sender.InLobby)
                 _packetDispatcher.SendToPlayer(sender, new SetIsStartButtonEnabledPacket

--- a/BeatTogether.DedicatedServer.Kernel/Player.cs
+++ b/BeatTogether.DedicatedServer.Kernel/Player.cs
@@ -33,6 +33,8 @@ namespace BeatTogether.DedicatedServer.Kernel
 
         public PlayerStateHash State { get; set; } = new();
 
+        public bool WasActiveAtCountdownStart { get; set; } = false;
+
         public bool IsManager => UserId == Instance.Configuration.ManagerId;
         public bool CanRecommendBeatmaps => true;
         public bool CanRecommendModifiers =>


### PR DESCRIPTION
commented out code that was not being run before server changes i made which sent a signal to return to menu if someone left server gameplay when everyone server side is in lobby. could have started causing the quest black screen bug due to quest returning to lobby without server sending return packet at end of levels anyway. Will need testing though
Correctly sends countdown to players when it is in countdown stage and not starting beatmap stage as the game cancels the countdown if someone joins during the start beatmap stage of the countdown.

Added "server picks" logic code for the dedicated server.
Added a cancel countdown in case the beatmap is set to null during countdown (in case manager disconnects or "server picks" sets the beatmap to null to stop the countdown)