### PR TITLE
Players that dont exist but are sending packets still will be sent a …

### DIFF
--- a/BeatTogether.DedicatedServer.Kernel/Abstractions/IDedicatedInstance.cs
+++ b/BeatTogether.DedicatedServer.Kernel/Abstractions/IDedicatedInstance.cs
@@ -26,8 +26,6 @@ namespace BeatTogether.DedicatedServer.Kernel.Abstractions
 
         void SetupPermanentManager(string ManagerUsername);
         void SetupInstance(float Timeout, string ServerName);
-        void DisconnectPlayer(IPlayer player);
-        void DisconnectPlayer(string UserId);
 
         IPlayerRegistry GetPlayerRegistry();
         IServiceProvider GetServiceProvider();

--- a/BeatTogether.DedicatedServer.Kernel/DedicatedInstance.cs
+++ b/BeatTogether.DedicatedServer.Kernel/DedicatedInstance.cs
@@ -208,17 +208,6 @@ namespace BeatTogether.DedicatedServer.Kernel
             }, DeliveryMethod.ReliableOrdered);
         }
 
-        public void DisconnectPlayer(IPlayer player)
-        {
-            OnDisconnect(player.Endpoint, DisconnectReason.ConnectionRejected);
-        }
-
-        public void DisconnectPlayer(string UserId)
-        {
-            if(_playerRegistry.TryGetPlayer(UserId, out var player))
-                OnDisconnect(player.Endpoint, DisconnectReason.ConnectionRejected);
-        }
-
         #endregion
 
         #region LiteNetServer

--- a/BeatTogether.DedicatedServer.Kernel/Encryption/PacketEncryptionLayer.cs
+++ b/BeatTogether.DedicatedServer.Kernel/Encryption/PacketEncryptionLayer.cs
@@ -74,7 +74,7 @@ namespace BeatTogether.DedicatedServer.Kernel.Encryption
                 new HMACSHA256(sendMacSourceArray)
             );
             _potentialEncryptionParameters[endPoint.Address] = encryptionParameters;
-            _encryptionParameters.TryRemove(endPoint, out _);
+            _encryptionParameters.TryRemove(endPoint, out _); //Why we removing this here?
         }
 
         public void RemoveEncryptedEndPoint(IPEndPoint endPoint)
@@ -129,14 +129,25 @@ namespace BeatTogether.DedicatedServer.Kernel.Encryption
 
         public void ProcessOutBoundPacket(EndPoint endPoint, ref Span<byte> data)
         {
-            if (!_encryptionParameters.TryGetValue(endPoint, out var encryptionParameters))
+            if (!_encryptionParameters.TryGetValue(endPoint, out _))
             {
-                _logger.Warning(
-                    "Failed to retrieve encryption parameters " +
-                    $"(RemoteEndPoint='{endPoint}')."
-                );
-                return;
+                if (_potentialEncryptionParameters.TryGetValue(((IPEndPoint)endPoint).Address, out var encryptionParametersold))
+                {
+                    _logger.Warning($"Running cubics fix, this should not run but if it is i fixed something (RemoteEndPoint='{endPoint}').");
+                    _encryptionParameters.GetOrAdd(endPoint, encryptionParametersold);
+                    _encryptionParameters[endPoint] = encryptionParametersold;
+                }
+                else
+                {
+                    _logger.Warning(
+                        "Failed to retrieve encryption parameters " +
+                        $"(RemoteEndPoint='{endPoint}')."
+                    );
+                    return;
+                }
             }
+            //TODO make this more efficient, quick fix to make it possibly work happened here
+            var encryptionParameters = _encryptionParameters[endPoint];
 
             var bufferWriter = new SpanBufferWriter(stackalloc byte[412]);
             bufferWriter.WriteBool(true);  // isEncrypted

--- a/BeatTogether.DedicatedServer.Kernel/PacketDispatcher.cs
+++ b/BeatTogether.DedicatedServer.Kernel/PacketDispatcher.cs
@@ -9,6 +9,7 @@ using BeatTogether.LiteNetLib.Extensions;
 using Krypton.Buffers;
 using Serilog;
 using System;
+using System.Net;
 
 namespace BeatTogether.DedicatedServer.Kernel
 {
@@ -63,6 +64,20 @@ namespace BeatTogether.DedicatedServer.Kernel
             foreach (IPlayer player in _playerRegistry.Players)
                 if (player.ConnectionId != excludedPlayer.ConnectionId)
                     Send(player.Endpoint, writer.Data, deliveryMethod);
+        }
+
+        public void SendToEndpoint(EndPoint endpoint, INetSerializable packet, DeliveryMethod deliveryMethod)
+        {
+            _logger.Debug(
+                $"Sending packet of type '{packet.GetType().Name}' " +
+                $"(To endpoint ={endpoint})"
+            );
+
+            var writer = new SpanBufferWriter(stackalloc byte[412]);
+            writer.WriteRoutingHeader(LocalConnectionId, LocalConnectionId);
+            WriteOne(ref writer, packet);
+
+            Send(endpoint, writer.Data, deliveryMethod);
         }
 
         public void SendFromPlayer(IPlayer fromPlayer, INetSerializable packet, DeliveryMethod deliveryMethod)

--- a/BeatTogether.DedicatedServer.Kernel/PacketSource.cs
+++ b/BeatTogether.DedicatedServer.Kernel/PacketSource.cs
@@ -3,6 +3,7 @@ using System.Net;
 using System.Text;
 using System.Threading.Tasks;
 using BeatTogether.DedicatedServer.Kernel.Abstractions;
+using BeatTogether.DedicatedServer.Messaging.Packets;
 using BeatTogether.Extensions;
 using BeatTogether.LiteNetLib;
 using BeatTogether.LiteNetLib.Abstractions;
@@ -57,9 +58,14 @@ namespace BeatTogether.DedicatedServer.Kernel
             if (!_playerRegistry.TryGetPlayer(remoteEndPoint, out var sender))
             {
                 _logger.Warning(
-                    "Failed to retrieve sender " +
+                    "Failed to retrieve sender, sending them a disconnect packet " +
                     $"(RemoteEndPoint='{remoteEndPoint}')."
                 );
+                _packetDispatcher.SendToEndpoint(remoteEndPoint, //TODO this is only to disconnect users if they are somehow stuck. probably wont send if the player is not found anyway
+                    new PlayerDisconnectedPacket
+                    {
+                        DisconnectedReason = Messaging.Enums.DisconnectedReason.Timeout
+                    }, DeliveryMethod.ReliableOrdered);
                 return;
             }
 

--- a/BeatTogether.DedicatedServer.Node/MasterServerEventHandler.cs
+++ b/BeatTogether.DedicatedServer.Node/MasterServerEventHandler.cs
@@ -81,8 +81,8 @@ namespace BeatTogether.DedicatedServer.Node
 
         private Task HandleDisconnectPlayer(DisconnectPlayerFromMatchmakingServerEvent disconnectEvent)
         {
-            if(_instanceRegistry.TryGetInstance(disconnectEvent.Secret, out var instance))
-                instance.DisconnectPlayer(disconnectEvent.UserId);
+            //if(_instanceRegistry.TryGetInstance(disconnectEvent.Secret, out var instance))
+                //instance.DisconnectPlayer(disconnectEvent.UserId);
             return Task.CompletedTask;
         }
         #endregion

--- a/BeatTogether.DedicatedServer.Node/NodeService.cs
+++ b/BeatTogether.DedicatedServer.Node/NodeService.cs
@@ -250,7 +250,7 @@ namespace BeatTogether.DedicatedServer.Node
         {
             if (_instanceRegistry.TryGetInstance(request.Secret, out var instance))
             {
-                instance.DisconnectPlayer(instance.GetPlayerRegistry().GetPlayer(request.UserId));                
+                //instance.DisconnectPlayer(instance.GetPlayerRegistry().GetPlayer(request.UserId));                
                 return Task.FromResult(new KickPlayerResponse(true));
             }
             return Task.FromResult(new KickPlayerResponse(false));


### PR DESCRIPTION
…disconnect packet. If server is sending a player an outbound packet but cannot find the encryption it will try finding there prev encryption. Might fix something?