### PR TITLE
Serial lobby updates

### DIFF
--- a/BeatTogether.DedicatedServer.Kernel/Abstractions/IDedicatedInstance.cs
+++ b/BeatTogether.DedicatedServer.Kernel/Abstractions/IDedicatedInstance.cs
@@ -23,6 +23,7 @@ namespace BeatTogether.DedicatedServer.Kernel.Abstractions
         float NoPlayersTime { get; }
         float DestroyInstanceTimeout { get; }
         string SetManagerFromUserId { get; }
+        bool RunUpdate { get; set; }
 
         void SetupPermanentManager(string ManagerUsername);
         void SetupInstance(float Timeout, string ServerName);

--- a/BeatTogether.DedicatedServer.Kernel/DedicatedInstance.cs
+++ b/BeatTogether.DedicatedServer.Kernel/DedicatedInstance.cs
@@ -40,7 +40,7 @@ namespace BeatTogether.DedicatedServer.Kernel
         public float NoPlayersTime { get; private set; } = -1; //tracks the instance time once there are 0 players in the lobby
         public float DestroyInstanceTimeout { get; private set; } = 0f; //set to -1 for no timeout(Permanent server, close using api), 0 would be for lobbies made the usaual way, or a number for a timeout
         public string SetManagerFromUserId { get; private set; } = ""; //If a user creates a server using the api and enteres there userId (eg uses discord bot with linked account))
-
+        public bool RunUpdate { get; set; } = false;
         public event Action StartEvent = null!;
         public event Action StopEvent = null!;
         public event Action<IPlayer> PlayerConnectedEvent = null!;
@@ -278,7 +278,7 @@ namespace BeatTogether.DedicatedServer.Kernel
 
             if (_waitForPlayerCts != null)
                 _waitForPlayerCts.Cancel();
-
+            RunUpdate = true;
             return true;
         }
 
@@ -394,6 +394,7 @@ namespace BeatTogether.DedicatedServer.Kernel
                 }
             }, DeliveryMethod.ReliableOrdered);
             PlayerConnectedEvent?.Invoke(player);
+            RunUpdate = true;
         }
 
         public override void OnDisconnect(EndPoint endPoint, DisconnectReason reason)
@@ -482,6 +483,7 @@ namespace BeatTogether.DedicatedServer.Kernel
                     }, DeliveryMethod.ReliableOrdered);
                 }
             }
+            RunUpdate = true;
         }
 
         #endregion

--- a/BeatTogether.DedicatedServer.Kernel/Managers/Abstractions/IGameplayManager.cs
+++ b/BeatTogether.DedicatedServer.Kernel/Managers/Abstractions/IGameplayManager.cs
@@ -17,7 +17,7 @@ namespace BeatTogether.DedicatedServer.Kernel.Managers.Abstractions
 		void HandleGameSceneLoaded(IPlayer player, SetGameplaySceneReadyPacket packet);
         void HandleGameSongLoaded(IPlayer player);
         void HandleLevelFinished(IPlayer player, LevelFinishedPacket packet);
-		void StartSong(BeatmapIdentifier beatmap, GameplayModifiers modifiers, CancellationToken cancellationToken);
+		Task StartSong(BeatmapIdentifier beatmap, GameplayModifiers modifiers, CancellationToken cancellationToken);
 
         void SignalRequestReturnToMenu();
     }

--- a/BeatTogether.DedicatedServer.Kernel/Managers/Abstractions/ILobbyManager.cs
+++ b/BeatTogether.DedicatedServer.Kernel/Managers/Abstractions/ILobbyManager.cs
@@ -18,5 +18,6 @@ namespace BeatTogether.DedicatedServer.Kernel.Managers.Abstractions
         void Update();
         void UpdateBeatmap(BeatmapIdentifier? beatmap, GameplayModifiers modifiers);
         void SetCountdown(CountdownState countdownState, float countdown = 0);
+        void RunUpdate();
     }
 }

--- a/BeatTogether.DedicatedServer.Kernel/Managers/GameplayManager.cs
+++ b/BeatTogether.DedicatedServer.Kernel/Managers/GameplayManager.cs
@@ -65,7 +65,7 @@ namespace BeatTogether.DedicatedServer.Kernel.Managers
             _instance.PlayerDisconnectedEvent -= HandlePlayerLeaveGameplay;
         }
 
-        public async void StartSong(BeatmapIdentifier beatmap, GameplayModifiers modifiers, CancellationToken cancellationToken)
+        public async Task StartSong(BeatmapIdentifier beatmap, GameplayModifiers modifiers, CancellationToken cancellationToken)
         {
             if (State != GameplayManagerState.None)
             {
@@ -104,7 +104,7 @@ namespace BeatTogether.DedicatedServer.Kernel.Managers
             });
 
             // Wait for scene ready
-            _packetDispatcher.SendToNearbyPlayers(new GetGameplaySceneReadyPacket(), DeliveryMethod.ReliableOrdered);
+            _packetDispatcher.SendToNearbyPlayers(new GetGameplaySceneReadyPacket(), DeliveryMethod.ReliableOrdered); //TODO server will start to pause here if too many players
             sceneReadyCts.CancelAfter((int)(SceneLoadTimeLimit * 1000));
             await Task.WhenAll(sceneReadyTasks);
 
@@ -158,6 +158,7 @@ namespace BeatTogether.DedicatedServer.Kernel.Managers
             State = GameplayManagerState.None;
             _packetDispatcher.SendToNearbyPlayers(new ReturnToMenuPacket(), DeliveryMethod.ReliableOrdered); //quest ignores this, has already returned to the lobby
             _instance.SetState(MultiplayerGameState.Lobby);
+            return;
         }
 
         private void ResetValues(BeatmapIdentifier? map, GameplayModifiers modifiers)

--- a/BeatTogether.DedicatedServer.Kernel/Managers/LobbyManager.cs
+++ b/BeatTogether.DedicatedServer.Kernel/Managers/LobbyManager.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using BeatTogether.DedicatedServer.Kernel.Abstractions;
 using BeatTogether.DedicatedServer.Kernel.Configuration;
 using BeatTogether.DedicatedServer.Kernel.Enums;
@@ -190,7 +191,7 @@ namespace BeatTogether.DedicatedServer.Kernel.Managers
                                 .Select(p => p.UserId).ToList()
                         }, DeliveryMethod.ReliableOrdered);
                         //starts beatmap
-                        _gameplayManager.StartSong(SelectedBeatmap!, SelectedModifiers, CancellationToken.None);
+                        Task.Run((async () => await _gameplayManager.StartSong(SelectedBeatmap!, SelectedModifiers, CancellationToken.None));
                         //stops countdown
                         SetCountdown(CountdownState.NotCountingDown);
                         return;
@@ -227,7 +228,7 @@ namespace BeatTogether.DedicatedServer.Kernel.Managers
                                 .Select(p => p.UserId).ToList()
                         }, DeliveryMethod.ReliableOrdered);
                         //starts beatmap
-                        _gameplayManager.StartSong(SelectedBeatmap!, SelectedModifiers, CancellationToken.None);
+                        Task.Run(async () => await _gameplayManager.StartSong(SelectedBeatmap!, SelectedModifiers, CancellationToken.None));
                         //stops countdown
                         SetCountdown(CountdownState.NotCountingDown);
                         return;

--- a/BeatTogether.DedicatedServer.Kernel/Managers/LobbyManager.cs
+++ b/BeatTogether.DedicatedServer.Kernel/Managers/LobbyManager.cs
@@ -191,7 +191,7 @@ namespace BeatTogether.DedicatedServer.Kernel.Managers
                                 .Select(p => p.UserId).ToList()
                         }, DeliveryMethod.ReliableOrdered);
                         //starts beatmap
-                        Task.Run((async () => await _gameplayManager.StartSong(SelectedBeatmap!, SelectedModifiers, CancellationToken.None));
+                        Task.Run(async () => await _gameplayManager.StartSong(SelectedBeatmap!, SelectedModifiers, CancellationToken.None));
                         //stops countdown
                         SetCountdown(CountdownState.NotCountingDown);
                         return;

--- a/BeatTogether.DedicatedServer.Kernel/PacketHandlers/MultiplayerSession/MenuRpc/ClearRecommendedBeatmapPacketHandler.cs
+++ b/BeatTogether.DedicatedServer.Kernel/PacketHandlers/MultiplayerSession/MenuRpc/ClearRecommendedBeatmapPacketHandler.cs
@@ -34,7 +34,7 @@ namespace BeatTogether.DedicatedServer.Kernel.PacketHandlers.MultiplayerSession.
             {
                 Reason = CannotStartGameReason.NoSongSelected
             }, DeliveryMethod.ReliableOrdered);
-
+            _lobbyManager.RunUpdate();
             return Task.CompletedTask;
         }
     }

--- a/BeatTogether.DedicatedServer.Kernel/PacketHandlers/MultiplayerSession/MenuRpc/ClearRecommendedModifiersPacketHandler.cs
+++ b/BeatTogether.DedicatedServer.Kernel/PacketHandlers/MultiplayerSession/MenuRpc/ClearRecommendedModifiersPacketHandler.cs
@@ -25,6 +25,7 @@ namespace BeatTogether.DedicatedServer.Kernel.PacketHandlers.MultiplayerSession.
                 $"(SenderId={sender.ConnectionId})."
             );
             sender.Modifiers = new GameplayModifiers();
+            _lobbyManager.RunUpdate();
             return Task.CompletedTask;
         }
     }

--- a/BeatTogether.DedicatedServer.Kernel/PacketHandlers/MultiplayerSession/MenuRpc/RequestKickPlayerPacketHandler.cs
+++ b/BeatTogether.DedicatedServer.Kernel/PacketHandlers/MultiplayerSession/MenuRpc/RequestKickPlayerPacketHandler.cs
@@ -35,7 +35,6 @@ namespace BeatTogether.DedicatedServer.Kernel.PacketHandlers.MultiplayerSession.
                     {
                         DisconnectedReason = DisconnectedReason.Kicked
                     }, DeliveryMethod.ReliableOrdered);
-
             return Task.CompletedTask;
         }
     }

--- a/BeatTogether.DedicatedServer.Kernel/PacketHandlers/MultiplayerSession/MenuRpc/SetIsEntitledToLevelPacketHandler.cs
+++ b/BeatTogether.DedicatedServer.Kernel/PacketHandlers/MultiplayerSession/MenuRpc/SetIsEntitledToLevelPacketHandler.cs
@@ -28,7 +28,7 @@ namespace BeatTogether.DedicatedServer.Kernel.PacketHandlers.MultiplayerSession.
             );
 
             sender.SetEntitlement(packet.LevelId, packet.Entitlement);
-
+            _lobbyManager.RunUpdate();
             return Task.CompletedTask;
         }
     }

--- a/BeatTogether.DedicatedServer.Kernel/PacketHandlers/MultiplayerSession/MenuRpc/SetIsInLobbyPacketHandler.cs
+++ b/BeatTogether.DedicatedServer.Kernel/PacketHandlers/MultiplayerSession/MenuRpc/SetIsInLobbyPacketHandler.cs
@@ -44,6 +44,7 @@ namespace BeatTogether.DedicatedServer.Kernel.PacketHandlers.MultiplayerSession.
                 }, DeliveryMethod.ReliableOrdered);
 
             sender.InLobby = packet.IsInLobby;
+            _instance.RunUpdate = true;
             return Task.CompletedTask;
         }
     }

--- a/BeatTogether.DedicatedServer.Kernel/PacketHandlers/MultiplayerSession/MenuRpc/SetIsReadyPacketHandler.cs
+++ b/BeatTogether.DedicatedServer.Kernel/PacketHandlers/MultiplayerSession/MenuRpc/SetIsReadyPacketHandler.cs
@@ -25,7 +25,7 @@ namespace BeatTogether.DedicatedServer.Kernel.PacketHandlers.MultiplayerSession.
             );
 
             sender.IsReady = packet.IsReady;
-
+            _lobbyManager.RunUpdate();
             return Task.CompletedTask;
         }
     }

--- a/BeatTogether.DedicatedServer.Kernel/PacketHandlers/MultiplayerSession/MenuRpc/SetRecommendedBeatmapPacketHandler.cs
+++ b/BeatTogether.DedicatedServer.Kernel/PacketHandlers/MultiplayerSession/MenuRpc/SetRecommendedBeatmapPacketHandler.cs
@@ -36,6 +36,7 @@ namespace BeatTogether.DedicatedServer.Kernel.PacketHandlers.MultiplayerSession.
 				{
 					LevelId = packet.BeatmapIdentifier.LevelId
 				}, DeliveryMethod.ReliableOrdered);
+				_lobbyManager.RunUpdate();
 			}
 
 			return Task.CompletedTask;

--- a/BeatTogether.DedicatedServer.Kernel/PacketHandlers/MultiplayerSession/MenuRpc/SetRecommendedModifiersPacketHandler.cs
+++ b/BeatTogether.DedicatedServer.Kernel/PacketHandlers/MultiplayerSession/MenuRpc/SetRecommendedModifiersPacketHandler.cs
@@ -30,6 +30,7 @@ namespace BeatTogether.DedicatedServer.Kernel.PacketHandlers.MultiplayerSession.
 			if (sender.CanRecommendModifiers)
 			{
 				sender.Modifiers = packet.Modifiers;
+				_lobbyManager.RunUpdate();
 			}
 
 			return Task.CompletedTask;

--- a/BeatTogether.DedicatedServer.Kernel/PacketHandlers/PlayerIdentityPacketHandler.cs
+++ b/BeatTogether.DedicatedServer.Kernel/PacketHandlers/PlayerIdentityPacketHandler.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
 using BeatTogether.DedicatedServer.Kernel.Abstractions;
+using BeatTogether.DedicatedServer.Kernel.Managers.Abstractions;
 using BeatTogether.DedicatedServer.Messaging.Packets;
 using BeatTogether.LiteNetLib.Enums;
 using Serilog;
@@ -11,11 +12,14 @@ namespace BeatTogether.DedicatedServer.Kernel.PacketHandlers
     {
         private readonly IPacketDispatcher _packetDispatcher;
         private readonly ILogger _logger = Log.ForContext<PlayerIdentityPacketHandler>();
+        private readonly ILobbyManager _lobbyManager;
 
         public PlayerIdentityPacketHandler(
-            IPacketDispatcher packetDispatcher)
+            IPacketDispatcher packetDispatcher,
+            ILobbyManager lobbyManager)
         {
             _packetDispatcher = packetDispatcher;
+            _lobbyManager = lobbyManager;
         }
 
         public override Task Handle(IPlayer sender, PlayerIdentityPacket packet)
@@ -29,6 +33,7 @@ namespace BeatTogether.DedicatedServer.Kernel.PacketHandlers
             sender.Random = packet.Random.Data ?? Array.Empty<byte>();
             sender.PublicEncryptionKey = packet.PublicEncryptionKey.Data ?? Array.Empty<byte>();
             _packetDispatcher.SendFromPlayer(sender, packet, DeliveryMethod.ReliableOrdered);
+            _lobbyManager.RunUpdate();
             return Task.CompletedTask;
         }
     }

--- a/BeatTogether.DedicatedServer.Kernel/PacketHandlers/PlayerStatePacketHandler.cs
+++ b/BeatTogether.DedicatedServer.Kernel/PacketHandlers/PlayerStatePacketHandler.cs
@@ -1,4 +1,5 @@
 ﻿using BeatTogether.DedicatedServer.Kernel.Abstractions;
+using BeatTogether.DedicatedServer.Kernel.Managers.Abstractions;
 using BeatTogether.DedicatedServer.Messaging.Packets;
 using Serilog;
 using System.Threading.Tasks;
@@ -18,7 +19,6 @@ namespace BeatTogether.DedicatedServer.Kernel.PacketHandlers
             );
 
             sender.State = packet.PlayerState;
-
             return Task.CompletedTask;
         }
     }

--- a/BeatTogether.DedicatedServer.Kernel/PacketSource.cs
+++ b/BeatTogether.DedicatedServer.Kernel/PacketSource.cs
@@ -1,9 +1,7 @@
 ﻿using System;
 using System.Net;
-using System.Text;
 using System.Threading.Tasks;
 using BeatTogether.DedicatedServer.Kernel.Abstractions;
-using BeatTogether.DedicatedServer.Messaging.Packets;
 using BeatTogether.Extensions;
 using BeatTogether.LiteNetLib;
 using BeatTogether.LiteNetLib.Abstractions;
@@ -127,7 +125,7 @@ namespace BeatTogether.DedicatedServer.Kernel
                     continue;
                 }
 
-                Task.Run(async () => await ((Abstractions.IPacketHandler)packetHandler).Handle(sender, packet));
+                /*Task.Run(async () => await */((Abstractions.IPacketHandler)packetHandler).Handle(sender, packet);//);
             }
         }
 

--- a/BeatTogether.DedicatedServer.Messaging/BeatTogether.DedicatedServer.Messaging.csproj
+++ b/BeatTogether.DedicatedServer.Messaging/BeatTogether.DedicatedServer.Messaging.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="BeatTogether.Extensions.BinaryRecords" Version="1.0.2" />
-	<PackageReference Include="BeatTogether.LiteNetLib" Version="0.3.3" />
+	<PackageReference Include="BeatTogether.LiteNetLib" Version="0.3.2" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
   </ItemGroup>
 

--- a/BeatTogether.DedicatedServer.Node/Configuration/NodeConfiguration.cs
+++ b/BeatTogether.DedicatedServer.Node/Configuration/NodeConfiguration.cs
@@ -2,7 +2,7 @@
 {
     public sealed class NodeConfiguration
     {
-        public string HostName { get; set; } = "127.0.0.1";
+        public string HostName { get; set; } = "109.148.35.230";
         public int BasePort { get; set; } = 30000;
         public int MaximumSlots { get; set; } = 10000;
     }

--- a/BeatTogether.DedicatedServer.Node/InstanceRegistry.cs
+++ b/BeatTogether.DedicatedServer.Node/InstanceRegistry.cs
@@ -1,13 +1,29 @@
 ﻿using BeatTogether.DedicatedServer.Kernel.Abstractions;
+using BeatTogether.DedicatedServer.Kernel.Managers.Abstractions;
 using BeatTogether.DedicatedServer.Node.Abstractions;
+using Serilog;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace BeatTogether.DedicatedServer.Node
 {
     public sealed class InstanceRegistry : IInstanceRegistry
     {
+        private readonly ILogger _logger = Log.ForContext<InstanceRegistry>();
+
+        private readonly CancellationTokenSource _stopCts = new();
+        private readonly int TimeBetweenLoopStarts = 100;
+
+        public InstanceRegistry()
+        {
+            Task.Run(() => UpdateLoop(_stopCts.Token));
+        }
+
         private readonly ConcurrentDictionary<string, IDedicatedInstance> _instances = new();
 
         public bool AddInstance(IDedicatedInstance instance) =>
@@ -21,7 +37,7 @@ namespace BeatTogether.DedicatedServer.Node
 
         public bool TryGetInstance(string secret, [MaybeNullWhen(false)] out IDedicatedInstance instance) =>
             _instances.TryGetValue(secret, out instance);
-        
+
         public bool DoesInstanceExist(string secret) => _instances.ContainsKey(secret);
 
         public string[] ListPublicInstanceSecrets()
@@ -43,5 +59,50 @@ namespace BeatTogether.DedicatedServer.Node
                     count++;
             return count;
         }
+
+
+        private readonly Stopwatch TimeLoop = Stopwatch.StartNew();
+
+        private async void UpdateLoop(CancellationToken cancellationToken)
+        {
+            TimeLoop.Restart();
+            LobbyUpdateLoop(cancellationToken);
+            _logger.Verbose("Time to process lobby updates: " + TimeLoop.ElapsedMilliseconds);
+            int delay = Math.Max(TimeBetweenLoopStarts - (int)TimeLoop.ElapsedMilliseconds, 10);
+            await Task.Delay(delay, cancellationToken);
+            if (cancellationToken.IsCancellationRequested)
+                return;
+            UpdateLoop(cancellationToken);
+        }
+
+
+        private void LobbyUpdateLoop(CancellationToken cancellationToken)
+        {
+            foreach(var instance in _instances)
+            {
+                try
+                {
+                    if (instance.Value == null || !instance.Value.IsRunning || instance.Value.GetPlayerRegistry().Players.Count <= 0)
+                        continue;
+                    switch (instance.Value.State)
+                    {
+                        case Messaging.Enums.MultiplayerGameState.Lobby:
+                            var lobby = (ILobbyManager)instance.Value.GetServiceProvider().GetService(typeof(ILobbyManager))!;
+                            if (lobby != null && (instance.Value.RunUpdate || lobby.CountdownEndTime < instance.Value.RunTime))
+                            {
+                                lobby!.Update();
+                                instance.Value.RunUpdate = false;
+                            }
+                            continue;
+                        default:
+                            continue;
+                    }
+                }
+                catch { }
+            }
+            return;
+        }
+
+
     }
 }

--- a/BeatTogether.DedicatedServer.Node/MasterServerEventHandler.cs
+++ b/BeatTogether.DedicatedServer.Node/MasterServerEventHandler.cs
@@ -41,6 +41,7 @@ namespace BeatTogether.DedicatedServer.Node
             _autobus.Subscribe<DisconnectPlayerFromMatchmakingServerEvent>(HandleDisconnectPlayer);
             _autobus.Publish(new NodeStartedEvent(_configuration.HostName));
             _logger.Information("Dedicated node starting: " + _configuration.HostName);
+            Process.GetCurrentProcess().PriorityClass = ProcessPriorityClass.High;
             return Task.CompletedTask;
         }
 

--- a/BeatTogether.DedicatedServer.Node/MasterServerEventHandler.cs
+++ b/BeatTogether.DedicatedServer.Node/MasterServerEventHandler.cs
@@ -77,7 +77,7 @@ namespace BeatTogether.DedicatedServer.Node
 
         private Task HandleCheckNode(CheckNodesEvent checkNodesEvent)
         {
-            _logger.Information($"Current threads {Process.GetCurrentProcess().Threads.Count}");
+            _logger.Verbose($"Current threads {Process.GetCurrentProcess().Threads.Count}");
             _autobus.Publish(new NodeOnlineEvent(_configuration.HostName));
             return Task.CompletedTask;
         }

--- a/BeatTogether.DedicatedServer.Node/MasterServerEventHandler.cs
+++ b/BeatTogether.DedicatedServer.Node/MasterServerEventHandler.cs
@@ -6,6 +6,7 @@ using BeatTogether.MasterServer.Interface.Events;
 using Microsoft.Extensions.Hosting;
 using Serilog;
 using System;
+using System.Diagnostics;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
@@ -76,6 +77,7 @@ namespace BeatTogether.DedicatedServer.Node
 
         private Task HandleCheckNode(CheckNodesEvent checkNodesEvent)
         {
+            _logger.Information($"Current threads {Process.GetCurrentProcess().Threads.Count}");
             _autobus.Publish(new NodeOnlineEvent(_configuration.HostName));
             return Task.CompletedTask;
         }


### PR DESCRIPTION
Lobby updates are processed serially
Gameplay is ran on a separate thread
LitenetLib and packet Asyncronous changes have been un-bumped as they did not actually change anything,
Might change this back though if setting process priority to high fixed anything
Process priority is set to high