### PR TITLE
Add VersionRange to lobbies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -348,3 +348,4 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+/BeatTogether.DedicatedServer/appsettings.LocalDevelopment.json

--- a/BeatTogether.DedicatedServer.Instancing/Abstractions/IInstanceRegistry.cs
+++ b/BeatTogether.DedicatedServer.Instancing/Abstractions/IInstanceRegistry.cs
@@ -1,6 +1,7 @@
 ﻿using BeatTogether.Core.Enums;
 using BeatTogether.DedicatedServer.Kernel.Abstractions;
 using System.Diagnostics.CodeAnalysis;
+using BeatTogether.Core.Models;
 
 namespace BeatTogether.DedicatedServer.Instancing.Abstractions
 {
@@ -10,6 +11,6 @@ namespace BeatTogether.DedicatedServer.Instancing.Abstractions
         public bool RemoveInstance(IDedicatedInstance instance);
         public bool TryGetInstance(string secret, [MaybeNullWhen(false)] out IDedicatedInstance instance);
         public bool TryGetInstanceByCode(string code, [MaybeNullWhen(false)] out IDedicatedInstance instance);
-        public bool TryGetAvailablePublicServer(InvitePolicy invitePolicy, GameplayServerMode serverMode, SongSelectionMode songMode, GameplayServerControlSettings serverControlSettings, BeatmapDifficultyMask difficultyMask, GameplayModifiersMask modifiersMask, string songPackMasks, [MaybeNullWhen(false)] out IDedicatedInstance instance);
+        public bool TryGetAvailablePublicServer(InvitePolicy invitePolicy, GameplayServerMode serverMode, SongSelectionMode songMode, GameplayServerControlSettings serverControlSettings, BeatmapDifficultyMask difficultyMask, GameplayModifiersMask modifiersMask, string songPackMasks, VersionRange versionRange, [MaybeNullWhen(false)] out IDedicatedInstance instance);
     }
 }

--- a/BeatTogether.DedicatedServer.Instancing/BeatTogether.DedicatedServer.Instancing.csproj
+++ b/BeatTogether.DedicatedServer.Instancing/BeatTogether.DedicatedServer.Instancing.csproj
@@ -7,12 +7,12 @@
     <Authors>BeatTogether Team</Authors>
     <Company>BeatTogether</Company>
     <RepositoryUrl>https://github.com/beattogether/BeatTogether.DedicatedServer</RepositoryUrl>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BeatTogether.Core" Version="1.1.0" />
+    <PackageReference Include="BeatTogether.Core" Version="1.2.0-dev.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/BeatTogether.DedicatedServer.Instancing/BeatTogether.DedicatedServer.Instancing.csproj
+++ b/BeatTogether.DedicatedServer.Instancing/BeatTogether.DedicatedServer.Instancing.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BeatTogether.Core" Version="1.2.0-dev.3" />
+    <PackageReference Include="BeatTogether.Core" Version="1.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/BeatTogether.DedicatedServer.Instancing/Implimentations/ServerInstance.cs
+++ b/BeatTogether.DedicatedServer.Instancing/Implimentations/ServerInstance.cs
@@ -42,5 +42,6 @@ namespace BeatTogether.DedicatedServer.Instancing.Implimentations
         public bool AllowChroma { get => _ServerInstance._configuration.AllowChroma; set => throw new NotImplementedException(); }
         public bool AllowME { get => _ServerInstance._configuration.AllowMappingExtensions; set => throw new NotImplementedException(); }
         public bool AllowNE { get => _ServerInstance._configuration.AllowNoodleExtensions; set => throw new NotImplementedException(); }
-    }
+        public VersionRange SupportedVersionRange { get => _ServerInstance._configuration.SupportedVersionRange; set => throw new NotImplementedException(); }
+	}
 }

--- a/BeatTogether.DedicatedServer.Instancing/InstanceRegistry.cs
+++ b/BeatTogether.DedicatedServer.Instancing/InstanceRegistry.cs
@@ -4,6 +4,7 @@ using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
 using BeatTogether.Core.Enums;
 using System.Linq;
+using BeatTogether.Core.Models;
 
 namespace BeatTogether.DedicatedServer.Instancing
 {
@@ -23,7 +24,7 @@ namespace BeatTogether.DedicatedServer.Instancing
 
         public bool RemoveInstance(IDedicatedInstance instance) => _instances.TryRemove(instance._configuration.Secret, out _) && _instancesByCode.TryRemove(instance._configuration.Code, out _);
 
-        public bool TryGetAvailablePublicServer(InvitePolicy invitePolicy, GameplayServerMode serverMode, SongSelectionMode songMode, GameplayServerControlSettings serverControlSettings, BeatmapDifficultyMask difficultyMask, GameplayModifiersMask modifiersMask, string songPackMasks, [MaybeNullWhen(false)] out IDedicatedInstance instance)
+        public bool TryGetAvailablePublicServer(InvitePolicy invitePolicy, GameplayServerMode serverMode, SongSelectionMode songMode, GameplayServerControlSettings serverControlSettings, BeatmapDifficultyMask difficultyMask, GameplayModifiersMask modifiersMask, string songPackMasks, VersionRange versionRange, [MaybeNullWhen(false)] out IDedicatedInstance instance)
         {
             instance = null;
             var AvaliableServers = _instances.Values.Where(s =>
@@ -33,7 +34,8 @@ namespace BeatTogether.DedicatedServer.Instancing
                 s._configuration.GameplayServerConfiguration.GameplayServerControlSettings == serverControlSettings &&
                 s._configuration.BeatmapDifficultyMask == difficultyMask &&
                 s._configuration.GameplayModifiersMask == modifiersMask &&
-                s._configuration.SongPacksMask == songPackMasks
+                s._configuration.SongPacksMask == songPackMasks &&
+                s._configuration.SupportedVersionRange == versionRange
                 );
             if (!AvaliableServers.Any())
                 return false;

--- a/BeatTogether.DedicatedServer.Instancing/LayerService.cs
+++ b/BeatTogether.DedicatedServer.Instancing/LayerService.cs
@@ -6,6 +6,7 @@ using BeatTogether.DedicatedServer.Instancing.Implimentations;
 using Serilog;
 using System.Net;
 using System.Threading.Tasks;
+using BeatTogether.Core.Models;
 
 namespace BeatTogether.DedicatedServer.Instancing
 {
@@ -50,10 +51,10 @@ namespace BeatTogether.DedicatedServer.Instancing
             return Task.CompletedTask;
         }
 
-        public Task<IServerInstance?> GetAvailablePublicServer(InvitePolicy invitePolicy, GameplayServerMode serverMode, SongSelectionMode songMode, GameplayServerControlSettings serverControlSettings, BeatmapDifficultyMask difficultyMask, GameplayModifiersMask modifiersMask, string songPackMasks)
+        public Task<IServerInstance?> GetAvailablePublicServer(InvitePolicy invitePolicy, GameplayServerMode serverMode, SongSelectionMode songMode, GameplayServerControlSettings serverControlSettings, BeatmapDifficultyMask difficultyMask, GameplayModifiersMask modifiersMask, string songPackMasks, VersionRange versionRange)
         {
             IServerInstance? serverInstance = null;
-            if (_instanceRegistry.TryGetAvailablePublicServer(invitePolicy, serverMode, songMode, serverControlSettings, difficultyMask, modifiersMask, songPackMasks, out var instance))
+            if (_instanceRegistry.TryGetAvailablePublicServer(invitePolicy, serverMode, songMode, serverControlSettings, difficultyMask, modifiersMask, songPackMasks, versionRange, out var instance))
             {
                 serverInstance = new ServerInstance(instance, IPEndPoint.Parse($"{_instancingConfiguration.HostEndpoint}:{instance._configuration.Port}"));
             }

--- a/BeatTogether.DedicatedServer.Interface/BeatTogether.DedicatedServer.Interface.csproj
+++ b/BeatTogether.DedicatedServer.Interface/BeatTogether.DedicatedServer.Interface.csproj
@@ -7,7 +7,7 @@
     <Authors>BeatTogether Team</Authors>
     <Company>BeatTogether</Company>
     <RepositoryUrl>https://github.com/beattogether/BeatTogether.DedicatedServer</RepositoryUrl>
-    <Version>2.0.2</Version>
+    <Version>2.1.0</Version>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
@@ -17,7 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="Autobus.Abstractions" Version="0.1.5" />
-    <PackageReference Include="BeatTogether.Core" Version="1.0.3" />
+    <PackageReference Include="BeatTogether.Core" Version="1.2.0-dev.3" />
   </ItemGroup>
 
 </Project>

--- a/BeatTogether.DedicatedServer.Interface/BeatTogether.DedicatedServer.Interface.csproj
+++ b/BeatTogether.DedicatedServer.Interface/BeatTogether.DedicatedServer.Interface.csproj
@@ -17,7 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="Autobus.Abstractions" Version="0.1.5" />
-    <PackageReference Include="BeatTogether.Core" Version="1.2.0-dev.3" />
+    <PackageReference Include="BeatTogether.Core" Version="1.2.0" />
   </ItemGroup>
 
 </Project>

--- a/BeatTogether.DedicatedServer.Kernel/BeatTogether.DedicatedServer.Kernel.csproj
+++ b/BeatTogether.DedicatedServer.Kernel/BeatTogether.DedicatedServer.Kernel.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BeatTogether.Core" Version="1.2.0-dev.3" />
+    <PackageReference Include="BeatTogether.Core" Version="1.2.0" />
     <PackageReference Include="BeatTogether.Core.Security" Version="1.2.0" />
     <PackageReference Include="BeatTogether.Extensions.Serilog" Version="2.1.0" />
     <PackageReference Include="System.Collections" Version="4.3.0" />

--- a/BeatTogether.DedicatedServer.Kernel/BeatTogether.DedicatedServer.Kernel.csproj
+++ b/BeatTogether.DedicatedServer.Kernel/BeatTogether.DedicatedServer.Kernel.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BeatTogether.Core" Version="1.1.0" />
+    <PackageReference Include="BeatTogether.Core" Version="1.2.0-dev.3" />
     <PackageReference Include="BeatTogether.Core.Security" Version="1.2.0" />
     <PackageReference Include="BeatTogether.Extensions.Serilog" Version="2.1.0" />
     <PackageReference Include="System.Collections" Version="4.3.0" />

--- a/BeatTogether.DedicatedServer.Kernel/Configuration/InstanceConfiguration.cs
+++ b/BeatTogether.DedicatedServer.Kernel/Configuration/InstanceConfiguration.cs
@@ -16,6 +16,8 @@ namespace BeatTogether.DedicatedServer.Kernel.Configuration
         public string SetConstantManagerFromUserId { get; set; } = string.Empty; //If a user creates a server using the api and enteres there userId (eg uses discord bot with linked account))
         public bool AllowPerPlayerDifficulties { get; set; } = false;
         public bool AllowPerPlayerModifiers { get; set; } = false;
+
+        public VersionRange SupportedVersionRange { get; set; } = new();
         public CountdownConfig CountdownConfig { get; set; } = new();
 
         public GameplayServerConfiguration GameplayServerConfiguration { get; set; } = new();

--- a/BeatTogether.DedicatedServer.Kernel/Managers/LobbyManager.cs
+++ b/BeatTogether.DedicatedServer.Kernel/Managers/LobbyManager.cs
@@ -472,6 +472,7 @@ namespace BeatTogether.DedicatedServer.Kernel.Managers
                     int Votes = 0;
                     foreach (var item in voteDictionary)
                     {
+                        _logger.Debug($"Checking Votes for map '{item.Key.LevelId}' on characteristic '{item.Key.Characteristic}' and difficulty '{item.Key.Difficulty}' votes: {item.Value}");
                         if (item.Value > Votes)
                         {
                             Selected = item.Key;

--- a/BeatTogether.DedicatedServer.Kernel/Managers/LobbyManager.cs
+++ b/BeatTogether.DedicatedServer.Kernel/Managers/LobbyManager.cs
@@ -472,7 +472,7 @@ namespace BeatTogether.DedicatedServer.Kernel.Managers
                     int Votes = 0;
                     foreach (var item in voteDictionary)
                     {
-                        _logger.Debug($"Checking Votes for map '{item.Key.LevelId}' on characteristic '{item.Key.Characteristic}' and difficulty '{item.Key.Difficulty}' votes: {item.Value}");
+                        _logger.Verbose($"Checking Votes for map '{item.Key.LevelId}' on characteristic '{item.Key.Characteristic}' and difficulty '{item.Key.Difficulty}' votes: {item.Value}");
                         if (item.Value > Votes)
                         {
                             Selected = item.Key;

--- a/BeatTogether.DedicatedServer.Kernel/Managers/LobbyManager.cs
+++ b/BeatTogether.DedicatedServer.Kernel/Managers/LobbyManager.cs
@@ -479,6 +479,7 @@ namespace BeatTogether.DedicatedServer.Kernel.Managers
                             Votes = item.Value;
                         }
                     }
+                    _logger.Verbose($"Vote: selected map '{Selected.LevelId}' characteristic '{Selected.Characteristic}' difficulty '{Selected.Difficulty}'");
                     return Selected;
                 case SongSelectionMode.RandomPlayerPicks:
                     if (CountDownState == CountdownState.CountingDown || CountDownState == CountdownState.NotCountingDown)

--- a/BeatTogether.DedicatedServer.Messaging/BeatTogether.DedicatedServer.Messaging.csproj
+++ b/BeatTogether.DedicatedServer.Messaging/BeatTogether.DedicatedServer.Messaging.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BeatTogether.Core" Version="1.2.0-dev.3" />
+    <PackageReference Include="BeatTogether.Core" Version="1.2.0" />
     <PackageReference Include="BeatTogether.Core.Messaging" Version="1.10.0" />
     <PackageReference Include="BeatTogether.Extensions.BinaryRecords" Version="1.1.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />

--- a/BeatTogether.DedicatedServer.Messaging/BeatTogether.DedicatedServer.Messaging.csproj
+++ b/BeatTogether.DedicatedServer.Messaging/BeatTogether.DedicatedServer.Messaging.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BeatTogether.Core" Version="1.1.0" />
+    <PackageReference Include="BeatTogether.Core" Version="1.2.0-dev.3" />
     <PackageReference Include="BeatTogether.Core.Messaging" Version="1.10.0" />
     <PackageReference Include="BeatTogether.Extensions.BinaryRecords" Version="1.1.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />

--- a/BeatTogether.DedicatedServer.Node/Configuration/NodeConfiguration.cs
+++ b/BeatTogether.DedicatedServer.Node/Configuration/NodeConfiguration.cs
@@ -5,6 +5,6 @@ namespace BeatTogether.DedicatedServer.Node.Configuration
     public sealed class NodeConfiguration
     {
         public string HostEndpoint { get; set; } = "127.0.0.1";
-        public Version NodeVersion { get; } = new Version(2,0,0);
+        public Version NodeVersion { get; } = new Version(2,1,0);
     }
 }

--- a/BeatTogether.DedicatedServer.Node/Models/ServerFromMessage.cs
+++ b/BeatTogether.DedicatedServer.Node/Models/ServerFromMessage.cs
@@ -50,6 +50,8 @@ namespace BeatTogether.DedicatedServer.Node.Models
 
         public bool AllowNE { get; set; }
 
+        public VersionRange SupportedVersionRange { get; set; }
+
         public IPEndPoint InstanceEndPoint { get; set; } = null!;
         public HashSet<string> PlayerHashes { get; set; } = null!;
 
@@ -76,6 +78,7 @@ namespace BeatTogether.DedicatedServer.Node.Models
             AllowChroma = instance.AllowChroma;
             AllowME = instance.AllowME;
             AllowNE = instance.AllowNE;
+            SupportedVersionRange = instance.SupportedVersionRange;
         }
     }
 }

--- a/BeatTogether.DedicatedServer/BeatTogether.DedicatedServer.csproj
+++ b/BeatTogether.DedicatedServer/BeatTogether.DedicatedServer.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/BeatTogether.DedicatedServer/BeatTogether.DedicatedServer.csproj
+++ b/BeatTogether.DedicatedServer/BeatTogether.DedicatedServer.csproj
@@ -19,6 +19,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Content Include="appsettings.LocalDevelopment.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <Content Include="appsettings.Development.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>

--- a/BeatTogether.DedicatedServer/BeatTogether.DedicatedServer.csproj
+++ b/BeatTogether.DedicatedServer/BeatTogether.DedicatedServer.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Remove="appsettings.Development.json" />
+    <None Remove="appsettings.*.json" />
     <None Remove="appsettings.json" />
     <None Update="cert.pem">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
@@ -19,10 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Content Include="appsettings.LocalDevelopment.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-    <Content Include="appsettings.Development.json">
+    <Content Include="appsettings.*.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <Content Include="appsettings.json">

--- a/BeatTogether.DedicatedServer/Properties/launchSettings.json
+++ b/BeatTogether.DedicatedServer/Properties/launchSettings.json
@@ -1,0 +1,11 @@
+{
+  "profiles": {
+    "BeatTogether.DedicatedServer": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "DOTNET_ENVIRONMENT": "LocalDevelopment"
+      },
+      "remoteDebugEnabled": false
+    }
+  }
+}

--- a/BeatTogether.DedicatedServer/appsettings.Development.json
+++ b/BeatTogether.DedicatedServer/appsettings.Development.json
@@ -1,6 +1,6 @@
 ﻿{
   "RabbitMQ": {
-    "HostName": "192.168.98.2"
+    "HostName": "127.0.0.1"
   },
   "Serilog": {
     "MinimumLevel": {

--- a/BeatTogether.DedicatedServer/appsettings.Development.json
+++ b/BeatTogether.DedicatedServer/appsettings.Development.json
@@ -1,4 +1,7 @@
 ﻿{
+  "RabbitMQ": {
+    "HostName": "192.168.98.2"
+  },
   "Serilog": {
     "MinimumLevel": {
       "Default": "Verbose",

--- a/BeatTogether.DedicatedServer/appsettings.json
+++ b/BeatTogether.DedicatedServer/appsettings.json
@@ -1,10 +1,13 @@
 ﻿{
+  "RabbitMQ": {
+    "HostName": "192.168.98.2"
+  },
   "Serilog": {
     "File": {
       "Path": "logs/BeatTogether.DedicatedServer-{Date}.log"
-    },
-    "ServerConfiguration": {
-      "HostEndpoint": "127.0.0.1"
     }
+  },
+  "ServerConfiguration": {
+    "HostEndpoint": "192.168.188.51"
   }
 }

--- a/BeatTogether.DedicatedServer/appsettings.json
+++ b/BeatTogether.DedicatedServer/appsettings.json
@@ -1,6 +1,6 @@
 ﻿{
   "RabbitMQ": {
-    "HostName": "192.168.98.2"
+    "HostName": "127.0.0.1"
   },
   "Serilog": {
     "File": {
@@ -8,6 +8,6 @@
     }
   },
   "ServerConfiguration": {
-    "HostEndpoint": "192.168.188.51"
+    "HostEndpoint": "127.0.0.1"
   }
 }


### PR DESCRIPTION
This PR adds version ranges to the lobbies this ensures players with incompatible versions can still play on the server, just not on the same lobby